### PR TITLE
Fix sample sitemapConfig in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,10 +343,10 @@ You can also do more complex element criterias, and manually add custom paths:
             'criteria' => ['section' => 'semiSecret', 'notThatSecret' => true],
             'params' => ['changefreq' => 'daily', 'priority' => 0.5],
         ],
-        'custom' => [
-            '/cookies' => ['changefreq' => 'weekly', 'priority' => 1],
-            '/terms-and-conditions' => ['changefreq' => 'weekly', 'priority' => 1],
-        ]
+    ],
+    'custom' => [
+        '/cookies' => ['changefreq' => 'weekly', 'priority' => 1],
+        '/terms-and-conditions' => ['changefreq' => 'weekly', 'priority' => 1],
     ],
 ],
 ``` 


### PR DESCRIPTION
The `custom` key under _Enabling Sitemaps_ was a child of `elements` instead of being a child of `sitemapConfig`.