### PR TITLE
Perform multi-byte safe maxLength enforcement

### DIFF
--- a/src/services/MetaService.php
+++ b/src/services/MetaService.php
@@ -455,7 +455,7 @@ class MetaService extends Component
 
                 if ($restrictions['type'] === 'text' && isset($restrictions['maxLength'])) {
                     if (\strlen($value) > $restrictions['maxLength']) {
-                        $meta[$key] = substr($value, 0, $restrictions['maxLength'] - strlen($settings->truncateSuffix)) . $settings->truncateSuffix;
+                        $meta[$key] = mb_substr($value, 0, $restrictions['maxLength'] - strlen($settings->truncateSuffix)) . $settings->truncateSuffix;
                     }
                 }
             }


### PR DESCRIPTION
The regular `substr` function trips up the entire page generation if the sub-string truncation happens to fall on a multi-byte character such as `—`. Using `mb_substr` fixes this as it is multi-byte safe.