### PR TITLE
Add support for manually generated sitemap links

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ Defines the content of the sitemaps. The configuration consists of two main
 keys, `elements` and `custom`. In `elements`, you can define sitemaps that 
 will automatically query for elements in certain sections or based on custom 
 criterias, and in `custom` you add paths that are added to a separate custom 
-sitemap.
+sitemap. You may also add links to manually generated sitemaps in `additionalSitemaps`.
 
 In the example below, we get all elements from the sections with handles 
 `projects` and `news`, query for entries in four specific 
@@ -753,6 +753,10 @@ we add two custom urls.
     'custom' => [
         '/custom-1' => ['changefreq' => 'weekly', 'priority' => 1],
         '/custom-2' => ['changefreq' => 'weekly', 'priority' => 1],
+    ],
+    'additionalSitemaps' => [
+        '/sitemap-from-other-plugin.xml',
+        '/manually-generated-sitemap.xml'
     ]
 ],
 ```

--- a/src/helpers/SitemapHelper.php
+++ b/src/helpers/SitemapHelper.php
@@ -74,22 +74,31 @@ class SitemapHelper
 
     /**
      * Returns sitemap url for custom sitemap for including in sitemap index
-     * 
+     *
      * @return array
      */
     public static function getCustomIndexSitemapUrl(): array
     {
         $settings = SEOMate::$plugin->getSettings();
-        
+        return self::getSitemapUrl($settings->sitemapName . '-custom.xml');
+    }
+
+    /**
+     * Returns sitemap url for sitemap with the given name
+     * @param $name
+     * @return array
+     */
+    public static function getSitemapUrl($name): array
+    {
         try {
             return [
-                'loc' => UrlHelper::siteUrl($settings->sitemapName . '-custom.xml'),
+                'loc' => UrlHelper::siteUrl($name),
                 'lastmod' => DateTimeHelper::currentUTCDateTime()->format('c')
             ];
         } catch (Exception $e) {
             Craft::error($e->getMessage(), __METHOD__);
         }
-        
+
         return [];
     }
 

--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -53,6 +53,7 @@ class SitemapService extends Component
         if (!empty($config)) {
             $elements = $config['elements'] ?? null;
             $custom = $config['custom'] ?? null;
+            $additionalSitemaps = $config['additionalSitemaps'] ?? null;
 
             if ($elements && \is_array($elements) && \count($elements) > 0) {
                 foreach ($elements as $key => $definition) {
@@ -64,6 +65,13 @@ class SitemapService extends Component
             if ($custom && \is_array($custom) && \count($custom) > 0) {
                 $customUrl = SitemapHelper::getCustomIndexSitemapUrl();
                 SitemapHelper::addUrlsToSitemap($document, $topNode, 'sitemap', [$customUrl]);
+            }
+
+            if ($additionalSitemaps && \is_array($additionalSitemaps) && \count($additionalSitemaps) > 0) {
+                foreach ($additionalSitemaps as $sitemap) {
+                    $addtnlSitemap = SitemapHelper::getSitemapUrl($sitemap);
+                    SitemapHelper::addUrlsToSitemap($document, $topNode, 'sitemap', [$addtnlSitemap]);
+                }
             }
             
             $data = $document->saveXML();


### PR DESCRIPTION
This will allow for sitemaps generated by other plugins or manually generated sitemaps to be directly linked to the SEOmate sitemap index