### PR TITLE
Void meta tags don't require a closing slash anymore

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -113,7 +113,7 @@ class Settings extends Model
     ];
 
     public array $tagTemplateMap = [
-        'default' => '<meta name="{{ key }}" content="{{ value }}"/>',
+        'default' => '<meta name="{{ key }}" content="{{ value }}">',
         'title' => '<title>{{ value }}</title>',
         '/^og:/,/^fb:/' => '<meta property="{{ key }}" content="{{ value }}">',
     ];

--- a/src/templates/_output/meta.twig
+++ b/src/templates/_output/meta.twig
@@ -1,10 +1,10 @@
 {% set meta = seomate.meta %}
-<link rel="home" href="{{ siteUrl() }}"/>
+<link rel="home" href="{{ siteUrl() }}">
 {% if craft.app.getResponse().getStatusCode() < 400 %}
 <link rel="canonical" href="{{ seomate.canonicalUrl }}">
-{% if meta['og:url'] is not defined %}<meta property="og:url" content="{{ seomate.canonicalUrl }}"/>{% endif %}
-{% if meta['twitter:url'] is not defined %}<meta name="twitter:url" content="{{ seomate.canonicalUrl }}"/>{% endif %}
-{% if meta['og:locale'] is not defined %}<meta property="og:locale" content="{{ craft.app.getSites().getCurrentSite().language }}"/>{% endif %}
+{% if meta['og:url'] is not defined %}<meta property="og:url" content="{{ seomate.canonicalUrl }}">{% endif %}
+{% if meta['twitter:url'] is not defined %}<meta name="twitter:url" content="{{ seomate.canonicalUrl }}">{% endif %}
+{% if meta['og:locale'] is not defined %}<meta property="og:locale" content="{{ craft.app.getSites().getCurrentSite().language }}">{% endif %}
 {% endif %}
 
 {% for key, data in meta %}
@@ -16,6 +16,6 @@
 {% set alternateUrls = seomate.alternateUrls ?? null %}
 {% if alternateUrls %}
     {% for alternateUrl in alternateUrls -%}
-        <link rel="alternate" href="{{ alternateUrl.url }}" hreflang="{{ alternateUrl.language }}"/>
+        <link rel="alternate" href="{{ alternateUrl.url }}" hreflang="{{ alternateUrl.language }}">
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
In HTML5 meta tags don't require a closing slash anymore (/), so there's no reason to still have it here :)