### PR TITLE
Feature/alternate in sitemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea
+composer.lock
+/vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 ### Added  
 - Sitemaps now include alternate URLs in `<xhtml:link>` entries, if the `outputAlternate` config setting is `true`.  
+- Sitemaps are now styled using an XSLT stylesheet.  
 ### Changed  
-- Elements without URIs are now explictly excluded from sitemaps.  
+- Elements without URIs are now explictly excluded from sitemaps.
 
 ## 2.1.1 - 2023-02-27
 ### Fixed  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SEOMate Changelog
 
+## Unreleased
+### Added  
+- Sitemaps now include alternate URLs in `<xhtml:link>` entries, if the `outputAlternate` config setting is `true`.  
+### Changed  
+- Elements without URIs are now explictly excluded from sitemaps.  
+
 ## 2.1.1 - 2023-02-27
 ### Fixed  
 - Fixes a template exception that could be thrown when rendering SEO previews   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added  
 - Sitemaps now include alternate URLs in `<xhtml:link>` entries, if the `outputAlternate` config setting is `true`.  
 - Sitemaps are now styled using an XSLT stylesheet.  
+### Improved  
+- Improved performance when outputting alternate URLs.  
 ### Changed  
 - Elements without URIs are now explictly excluded from sitemaps.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improved performance when outputting alternate URLs.  
 ### Changed  
 - Elements without URIs are now explictly excluded from sitemaps.
+- The `cacheDuration` config setting now works with PHP duration interval strings.  
 
 ## 2.1.2 - 2023-06-18
 ### Fixed

--- a/src/SEOMate.php
+++ b/src/SEOMate.php
@@ -155,6 +155,7 @@ class SEOMate extends Plugin
                     $event->rules[$sitemapName . '.xml'] = 'seomate/sitemap/index';
                     $event->rules[$sitemapName . '-<handle:\w*>-<page:\d*>.xml'] = 'seomate/sitemap/element';
                     $event->rules[$sitemapName . '-custom.xml'] = 'seomate/sitemap/custom';
+                    $event->rules['sitemap.xsl'] = 'seomate/sitemap/xsl';
                 }
             );
         }

--- a/src/assets/preview/PreviewAsset.php
+++ b/src/assets/preview/PreviewAsset.php
@@ -49,14 +49,15 @@ class PreviewAsset extends AssetBundle
         parent::registerAssetFiles($view);
 
         if ($view instanceof View) {
-            $settings = SEOMate::$plugin->getSettings();
-            $previewEnabled = $settings->previewEnabled;
 
-            if (!$this->shouldPreview($previewEnabled)) {
+
+            if (!$this->shouldPreview()) {
                 return;
             }
 
             $previewAction = Craft::$app->getSecurity()->hashData('seomate/preview');
+
+            $settings = SEOMate::$plugin->getSettings();
 
             $config = [
                 'previewAction' => $previewAction,
@@ -73,9 +74,12 @@ class PreviewAsset extends AssetBundle
      *
      *
      */
-    private function shouldPreview(bool|array|string $previewEnabled): bool
+    private function shouldPreview(): bool
     {
-        if ($previewEnabled === false) {
+
+        $settings = SEOMate::$plugin->getSettings();
+        $previewEnabled = $settings->previewEnabled;
+        if (!$previewEnabled) {
             return false;
         }
 
@@ -85,20 +89,19 @@ class PreviewAsset extends AssetBundle
         }
 
         if ($segments[0] === 'commerce') {
-            \array_shift($segments);
+            array_shift($segments);
         }
 
-        $currentSourceHandle = \in_array($segments[0], ['entries', 'categories', 'products']) ? $segments[1] ?? null : null;
+        $currentSourceHandle = in_array($segments[0], ['entries', 'categories', 'products']) ? $segments[1] ?? null : null;
         if (!$currentSourceHandle) {
             return false;
         }
 
-        if ($previewEnabled !== true) {
-            if (!\is_array($previewEnabled)) {
-                $previewEnabled = \explode(',', $previewEnabled);
+        if (!is_bool($previewEnabled)) {
+            if (!is_array($previewEnabled)) {
+                $previewEnabled = \explode(',', preg_replace('/\s+/', '', $previewEnabled));
             }
-
-            if (!\in_array($currentSourceHandle, $previewEnabled, true)) {
+            if (!in_array($currentSourceHandle, $previewEnabled, true)) {
                 return false;
             }
         }

--- a/src/controllers/PreviewController.php
+++ b/src/controllers/PreviewController.php
@@ -17,9 +17,8 @@ use craft\elements\Category;
 use craft\elements\Entry;
 use craft\web\Controller;
 use craft\web\Response;
-
 use craft\web\View;
-use vaersaagod\redirectmate\helpers\UrlHelper;
+
 use vaersaagod\seomate\SEOMate;
 
 use yii\base\Exception;
@@ -213,12 +212,15 @@ class PreviewController extends Controller
      */
     private function _getMetaFromHtml(?string $html): ?array
     {
-        if (!$html) {
+        if (empty($html)) {
             return null;
         }
         $tags = [];
-        $libxmlUseInternalErrors = \libxml_use_internal_errors(true);
-        $html = \mb_convert_encoding($html, 'HTML-ENTITIES', Craft::$app->getView()->getTwig()->getCharset());
+        $libxmlUseInternalErrors = libxml_use_internal_errors(true);
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', Craft::$app->getView()->getTwig()->getCharset());
+        if (!is_string($html)) {
+            return null;
+        }
         $doc = new \DOMDocument();
         $doc->loadHTML($html);
         $xpath = new \DOMXPath($doc);
@@ -234,7 +236,7 @@ class PreviewController extends Controller
         if ($title = $doc->getElementsByTagName('title')->item(0)?->nodeValue) {
             $tags['title'] = $title;
         }
-        \libxml_use_internal_errors($libxmlUseInternalErrors);
+        libxml_use_internal_errors($libxmlUseInternalErrors);
         return $tags;
     }
 }

--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -12,6 +12,7 @@ use Craft;
 use craft\web\Controller;
 
 use craft\web\Response;
+use craft\web\View;
 use vaersaagod\seomate\SEOMate;
 use yii\base\ExitException;
 
@@ -74,6 +75,24 @@ class SitemapController extends Controller
     {
         SEOMate::$plugin->sitemap->submit();
         Craft::$app->end();
+    }
+
+    /**
+     * @return Response|\yii\console\Response
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     * @throws \yii\base\Exception
+     */
+    public function actionXsl(): Response|\yii\console\Response
+    {
+        $xml = \Craft::$app->getView()->renderTemplate('seomate/_sitemaps/xsl.twig', [], View::TEMPLATE_MODE_CP);
+
+        $headers = Craft::$app->response->headers;
+        $headers->add('Content-Type', 'text/xml; charset=utf-8');
+        $headers->add('X-Robots-Tag', 'noindex');
+
+        return $this->asRaw($xml);
     }
 
     /**

--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -10,10 +10,11 @@ namespace vaersaagod\seomate\controllers;
 
 use Craft;
 use craft\web\Controller;
-
 use craft\web\Response;
 use craft\web\View;
+
 use vaersaagod\seomate\SEOMate;
+
 use yii\base\ExitException;
 
 /**
@@ -32,9 +33,10 @@ class SitemapController extends Controller
     /**
      * Action for returning index sitemap
      *
+     * @return Response
      * @throws \Throwable
      */
-    public function actionIndex(): Response|\yii\console\Response
+    public function actionIndex(): Response
     {
         return $this->returnXml(
             SEOMate::$plugin->sitemap->index()
@@ -44,9 +46,10 @@ class SitemapController extends Controller
     /**
      * Action for returning element sitemaps
      *
+     * @return Response
      * @throws \Throwable
      */
-    public function actionElement(): Response|\yii\console\Response
+    public function actionElement(): Response
     {
         $params = Craft::$app->getUrlManager()->getRouteParams();
 
@@ -56,9 +59,11 @@ class SitemapController extends Controller
     }
 
     /**
-     * Action for returning the custom sitemap
+     * Action for returning custom sitemaps
+     *
+     * @return Response
      */
-    public function actionCustom(): Response|\yii\console\Response
+    public function actionCustom(): Response
     {
         return $this->returnXml(
             SEOMate::$plugin->sitemap->custom()
@@ -68,6 +73,7 @@ class SitemapController extends Controller
     /**
      * Action for submitting sitemap to search engines
      *
+     * @return void
      * @throws ExitException
      * @throws \Throwable
      */
@@ -78,33 +84,31 @@ class SitemapController extends Controller
     }
 
     /**
-     * @return Response|\yii\console\Response
+     * Action for returning the XSLT sitemap stylesheet
+     *
+     * @return Response
      * @throws \Twig\Error\LoaderError
      * @throws \Twig\Error\RuntimeError
      * @throws \Twig\Error\SyntaxError
      * @throws \yii\base\Exception
      */
-    public function actionXsl(): Response|\yii\console\Response
+    public function actionXsl(): Response
     {
-        $xml = \Craft::$app->getView()->renderTemplate('seomate/_sitemaps/xsl.twig', [], View::TEMPLATE_MODE_CP);
-
-        $headers = Craft::$app->response->headers;
-        $headers->add('Content-Type', 'text/xml; charset=utf-8');
-        $headers->add('X-Robots-Tag', 'noindex');
-
-        return $this->asRaw($xml);
+        $xml = Craft::$app->getView()->renderTemplate('seomate/_sitemaps/xsl.twig', [], View::TEMPLATE_MODE_CP);
+        $this->response->headers->set('X-Robots-Tag', 'noindex');
+        return $this->returnXml($xml);
     }
 
     /**
      * Helper function for returning an XML response
      *
-     *
+     * @param string $data
+     * @return Response
      */
-    private function returnXml(string $data): Response|\yii\console\Response
+    private function returnXml(string $data): Response
     {
-        $response = Craft::$app->getResponse();
-        $response->content = $data;
-        $response->format = \yii\web\Response::FORMAT_XML;
-        return $response;
+        $this->response->content = $data;
+        $this->response->format = \yii\web\Response::FORMAT_XML;
+        return $this->response;
     }
 }

--- a/src/helpers/CacheHelper.php
+++ b/src/helpers/CacheHelper.php
@@ -10,7 +10,11 @@ namespace vaersaagod\seomate\helpers;
 
 use Craft;
 use craft\elements\Entry;
+use craft\helpers\ConfigHelper;
+
 use vaersaagod\seomate\SEOMate;
+
+use yii\base\InvalidConfigException;
 use yii\caching\TagDependency;
 
 /**
@@ -81,6 +85,7 @@ class CacheHelper
      * Checks if meta data cache for element exists
      *
      * @param $element
+     * @return bool
      */
     public static function hasMetaCacheForElement($element): bool
     {
@@ -92,6 +97,7 @@ class CacheHelper
      * Returns meta data cache for element
      *
      * @param $element
+     * @return mixed
      */
     public static function getMetaCacheForElement($element): mixed
     {
@@ -111,17 +117,17 @@ class CacheHelper
     }
 
     /**
-     * Creates cache for element meta data
-     *
      * @param $element
      * @param $meta
+     * @return void
+     * @throws \yii\base\InvalidConfigException
      */
     public static function setMetaCacheForElement($element, $meta): void
     {
         $settings = SEOMate::$plugin->getSettings();
 
         $cache = Craft::$app->getCache();
-        $cacheDuration = $settings->cacheDuration;
+        $cacheDuration = ConfigHelper::durationInSeconds($settings->cacheDuration);
 
         $dependency = new TagDependency([
             'tags' => [
@@ -138,6 +144,7 @@ class CacheHelper
      * Checks if cache for sitemap index exists
      *
      * @param $siteId
+     * @return bool
      */
     public static function hasCacheForSitemapIndex($siteId): bool
     {
@@ -149,6 +156,7 @@ class CacheHelper
      * Returns cached sitemap index
      *
      * @param $siteId
+     * @return mixed
      */
     public static function getCacheForSitemapIndex($siteId): mixed
     {
@@ -172,13 +180,14 @@ class CacheHelper
      *
      * @param $siteId
      * @param $data
+     * @throws InvalidConfigException
      */
     public static function setCacheForSitemapIndex($siteId, $data): void
     {
         $settings = SEOMate::$plugin->getSettings();
 
         $cache = Craft::$app->getCache();
-        $cacheDuration = $settings->cacheDuration;
+        $cacheDuration = ConfigHelper::durationInSeconds($settings->cacheDuration);
 
         $dependency = new TagDependency([
             'tags' => [

--- a/src/helpers/CacheHelper.php
+++ b/src/helpers/CacheHelper.php
@@ -256,13 +256,14 @@ class CacheHelper
      * @param $handle
      * @param $definition
      * @param $page
+     * @throws InvalidConfigException
      */
     public static function setCacheForElementSitemap($siteId, $data, $handle, $definition, $page): void
     {
         $settings = SEOMate::$plugin->getSettings();
 
         $cache = Craft::$app->getCache();
-        $cacheDuration = $settings->cacheDuration;
+        $cacheDuration = ConfigHelper::durationInSeconds($settings->cacheDuration);
 
         $tags = array_merge([self::SEOMATE_TAG, self::SITEMAP_ELEMENT_TAG], self::getElementSitemapTags($siteId, $handle, $definition));
 

--- a/src/helpers/SEOMateHelper.php
+++ b/src/helpers/SEOMateHelper.php
@@ -13,12 +13,13 @@ use craft\base\Element;
 use craft\base\ElementInterface;
 use craft\elements\Asset;
 use craft\elements\db\AssetQuery;
-use craft\elements\db\ElementQuery;
 use craft\elements\db\MatrixBlockQuery;
 use craft\elements\MatrixBlock;
 use craft\errors\SiteNotFoundException;
 use craft\helpers\UrlHelper;
+
 use Illuminate\Support\Collection;
+
 use vaersaagod\seomate\models\Settings;
 use vaersaagod\seomate\SEOMate;
 
@@ -131,7 +132,7 @@ class SEOMateHelper
      * @param string $handle
      * @param string $type
      * @return Asset|string|null
-     * @throws \yii\base\InvalidConfigException
+     * @throws \craft\errors\DeprecationException
      */
     public static function getPropertyDataByScopeAndHandle(ElementInterface|array $scope, string $handle, string $type): Asset|string|null
     {

--- a/src/helpers/SitemapHelper.php
+++ b/src/helpers/SitemapHelper.php
@@ -180,8 +180,13 @@ class SitemapHelper
     /**
      * Returns URLs for custom sitemap
      */
-    public static function getCustomSitemapUrls(array $customUrls): array
+    public static function getCustomSitemapUrls(?array $customUrls): array
     {
+
+        if (empty($customUrls)) {
+            return [];
+        }
+
         $urls = [];
 
         foreach ($customUrls as $key => $params) {

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -27,7 +27,7 @@ class Settings extends Model
 
     public int|string $cacheDuration = 3600;
 
-    public array|bool $previewEnabled = true;
+    public array|bool|string $previewEnabled = true;
 
     public string|null $previewLabel = null;
 

--- a/src/services/RenderService.php
+++ b/src/services/RenderService.php
@@ -13,6 +13,7 @@ use craft\base\Component;
 use craft\helpers\Template;
 
 use Twig\Markup;
+
 use vaersaagod\seomate\helpers\SEOMateHelper;
 use vaersaagod\seomate\SEOMate;
 
@@ -51,7 +52,7 @@ class RenderService extends Component
 
         $r = '';
 
-        if (!\is_array($value)) {
+        if (!is_array($value)) {
             $value = [$value];
         }
         

--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -40,7 +40,7 @@ class SitemapService extends Component
             return CacheHelper::getCacheForSitemapIndex($siteId);
         }
 
-        $document = new \DOMDocument('1.0', 'utf-8');
+        $document = $this->getSitemapDocument();
         $topNode = $this->getTopNode($document, 'sitemapindex');
         $document->appendChild($topNode);
         $comment = $document->createComment('Created on: ' . date('Y-m-d H:i:s'));
@@ -123,7 +123,7 @@ class SitemapService extends Component
         $settings = SEOMate::$plugin->getSettings();
         $siteId = Craft::$app->getSites()->getCurrentSite()->id;
 
-        $document = new \DOMDocument('1.0', 'utf-8');
+        $document = $this->getSitemapDocument();
         $topNode = $this->getTopNode($document);
         $document->appendChild($topNode);
         $comment = $document->createComment('Created on: ' . date('Y-m-d H:i:s'));
@@ -159,7 +159,7 @@ class SitemapService extends Component
     {
         $settings = SEOMate::$plugin->getSettings();
 
-        $document = new \DOMDocument('1.0', 'utf-8');
+        $document = $this->getSitemapDocument();
         $topNode = $this->getTopNode($document);
         $document->appendChild($topNode);
 
@@ -249,5 +249,16 @@ class SitemapService extends Component
         }
         
         return $node;
+    }
+
+    /**
+     * @return \DOMDocument
+     */
+    private function getSitemapDocument(): \DOMDocument
+    {
+        $document = new \DOMDocument('1.0', 'utf-8');
+        $xsl = $document->createProcessingInstruction('xml-stylesheet', 'type="text/xsl" href="sitemap.xsl"');
+        $document->appendChild($xsl);
+        return $document;
     }
 }

--- a/src/services/UrlsService.php
+++ b/src/services/UrlsService.php
@@ -14,12 +14,12 @@ use craft\base\Element;
 use craft\base\ElementInterface;
 use craft\errors\SiteNotFoundException;
 use craft\helpers\UrlHelper;
-use craft\models\Site;
 
 use vaersaagod\seomate\helpers\SEOMateHelper;
 use vaersaagod\seomate\SEOMate;
 
 use yii\base\Exception;
+use yii\base\InvalidConfigException;
 
 /**
  * @author    Værsågod
@@ -33,7 +33,9 @@ class UrlsService extends Component
      *
      * @param $context
      *
-     * @throws \Throwable
+     * @return string|null
+     * @throws Exception
+     * @throws InvalidConfigException
      */
     public function getCanonicalUrl($context): ?string
     {
@@ -125,7 +127,7 @@ class UrlsService extends Component
             !empty($settings->alternateFallbackSiteHandle) &&
             $fallbackSite = Craft::$app->getSites()->getSiteByHandle($settings->alternateFallbackSiteHandle, false)
         ) {
-            /** @var ElementInterface $fallbackSiteElement */
+            /** @var ElementInterface|null $fallbackSiteElement */
             $fallbackSiteElement = $siteElements->firstWhere('siteId', $fallbackSite->id);
             if ($fallbackSiteElement) {
                 $alternateUrls[] = [

--- a/src/templates/_sitemaps/xsl.twig
+++ b/src/templates/_sitemaps/xsl.twig
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+        version="1.0"
+        xmlns:sm="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+        xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+        xmlns:fo="http://www.w3.org/1999/XSL/Format"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns="http://www.w3.org/1999/xhtml">
+
+    <xsl:output method="html" indent="yes" encoding="UTF-8"/>
+
+    <xsl:template match="/">
+        <html>
+        <head>
+            <title>
+                Sitemap
+                <xsl:if test="sm:sitemapindex">Index</xsl:if>
+            </title>
+            <style type="text/css">
+                * {
+                    margin: 0;
+                    padding: 0;
+                }
+
+                body {
+                    color: #333;
+                    font-family: Arial;
+                    padding: 20px;
+                    font-size: 12px;
+                }
+
+                h1, h3 {
+                    margin-bottom: 10px;
+                }
+
+                h1 {
+                    font-size: 24px;
+                }
+
+                h3 {
+                    font-size: 16px;
+                }
+
+                h1 span {
+                    font-size: 16px;
+                    color: #555;
+                    margin-left: 5px;
+                }
+
+                p {
+                    line-height: 20px;
+                }
+
+                table {
+                    font-size: 12px;
+                }
+
+                table th {
+                    background: #f5f5f5;
+                }
+
+                table td, table th {
+                    border: 1px #ccc solid;
+                    padding: 5px;
+                    text-align: left;
+                }
+
+                table {
+                    border-collapse: collapse;
+                }
+
+                table span {
+                    background: #ddd;
+                    padding: 0 3px;
+                    margin-left: 5px;
+                }
+            </style>
+        </head>
+        <body>
+        <xsl:apply-templates/>
+        </body>
+        </html>
+    </xsl:template>
+
+    <xsl:template match="sm:sitemapindex">
+        <table cellpadding="0" cellspacing="0" border="0">
+            <tr>
+                <th></th>
+                <th>URL</th>
+                <th>Last Modified</th>
+            </tr>
+            <xsl:for-each select="sm:sitemap">
+                <tr>
+                    <xsl:variable name="loc">
+                        <xsl:value-of select="sm:loc"/>
+                    </xsl:variable>
+                    <xsl:variable name="pno">
+                        <xsl:value-of select="position()"/>
+                    </xsl:variable>
+                    <td>
+                        <xsl:value-of select="$pno"/>
+                    </td>
+                    <td>
+                        <a href="{$loc}">
+                            <xsl:value-of select="sm:loc"/>
+                        </a>
+                    </td>
+                    <xsl:apply-templates/>
+                </tr>
+            </xsl:for-each>
+        </table>
+    </xsl:template>
+
+    <xsl:template match="sm:urlset">
+        <table cellSpacing="0" cellPadding="0" border="0">
+            <tr>
+                <th></th>
+                <th>URL</th>
+                <xsl:if test="sm:url/sm:lastmod">
+                    <th>Last Modified</th>
+                </xsl:if>
+                <xsl:if test="sm:url/sm:changefreq">
+                    <th>Change Frequency</th>
+                </xsl:if>
+                <xsl:if test="sm:url/sm:priority">
+                    <th>Priority</th>
+                </xsl:if>
+            </tr>
+            <xsl:for-each select="sm:url">
+                <tr>
+                    <xsl:variable name="loc">
+                        <xsl:value-of select="sm:loc"/>
+                    </xsl:variable>
+                    <xsl:variable name="pno">
+                        <xsl:value-of select="position()"/>
+                    </xsl:variable>
+                    <td>
+                        <xsl:value-of select="$pno"/>
+                    </td>
+                    <td>
+                        <p>
+                            <a href="{$loc}">
+                                <xsl:value-of select="sm:loc"/>
+                            </a>
+                        </p>
+                        <xsl:apply-templates select="xhtml:*"/>
+                        <xsl:apply-templates select="image:*"/>
+                        <xsl:apply-templates select="video:*"/>
+                    </td>
+                    <xsl:apply-templates select="sm:*"/>
+                </tr>
+            </xsl:for-each>
+        </table>
+    </xsl:template>
+
+    <xsl:template match="sm:loc|image:loc|image:caption|video:*">
+    </xsl:template>
+
+    <xsl:template match="sm:lastmod|sm:changefreq|sm:priority">
+        <td>
+            <xsl:apply-templates/>
+        </td>
+    </xsl:template>
+
+    <xsl:template match="xhtml:link">
+        <xsl:variable name="altloc">
+            <xsl:value-of select="@href"/>
+        </xsl:variable>
+        <p>
+            Xhtml:
+            <a href="{$altloc}">
+                <xsl:value-of select="@href"/>
+            </a>
+            <xsl:if test="@hreflang">
+                <span>
+                    <xsl:value-of select="@hreflang"/>
+                </span>
+            </xsl:if>
+            <xsl:if test="@rel">
+                <span>
+                    <xsl:value-of select="@rel"/>
+                </span>
+            </xsl:if>
+            <xsl:if test="@media">
+                <span>
+                    <xsl:value-of select="@media"/>
+                </span>
+            </xsl:if>
+        </p>
+        <xsl:apply-templates/>
+    </xsl:template>
+    <xsl:template match="image:image">
+        <xsl:variable name="loc">
+            <xsl:value-of select="image:loc"/>
+        </xsl:variable>
+        <p>
+            Image:
+            <a href="{$loc}">
+                <xsl:value-of select="image:loc"/>
+            </a>
+            <span>
+                <xsl:value-of select="image:caption"/>
+            </span>
+            <xsl:apply-templates/>
+        </p>
+    </xsl:template>
+    <xsl:template match="video:video">
+        <xsl:variable name="loc">
+            <xsl:choose>
+                <xsl:when test="video:player_loc != ''">
+                    <xsl:value-of select="video:player_loc"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="video:content_loc"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <p>
+            Video:
+            <a href="{$loc}">
+                <xsl:choose>
+                    <xsl:when test="video:player_loc != ''">
+                        <xsl:value-of select="video:player_loc"/>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="video:content_loc"/>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </a>
+            <span>
+                <xsl:value-of select="video:title"/>
+            </span>
+            <span>
+                <xsl:value-of select="video:thumbnail_loc"/>
+            </span>
+            <xsl:apply-templates/>
+        </p>
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
This PR adds alternate URLs to sitemaps for multi-site entries, via `<xhtml:link>` elements - provided the [`outputAlternate`](https://github.com/vaersaagod/seomate#outputalternate-bool) SEOMate config setting is set to `true`.  

Additionally, the following changes are introduced:

* Sitemaps are now styled using an [XSLT stylesheet](https://github.com/vaersaagod/seomate/commit/e419291bf15d57443f27bb9b627b7fe219997cdc#diff-cf5babf5be42af4445f3378950cbe231a1597c24d4ef229141b5a1f7441e1c69). This change is somewhat borne out of necessity as introducing the `<xhtml:link>` element will actually prevent some browsers from visually rendering the sitemap XML.
* Performance when outputting alternate URLs has been [improved](https://github.com/vaersaagod/seomate/commit/e5ea1ac2dbdae26bb46d1d940ba61e5bf0b2994b). This change was primarily made to avoid performance issues with multi-site sitemaps, but it also benefits any multi-site entry template in cases where `outputAlternate` is enabled.
* Elements without URIs are now explicitly excluded from sitemaps. This feels like it sits right between a bug fix and an improvement, so let's just say it's a "change".

