### PR TITLE
Field profile map specificity and support for Commerce products and users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # SEOMate Changelog
 
+## Unreleased  
+### Fixed
+- Fixed a PHP exception that would occur when using the `{% seomateMeta %}` hook in nested entry templates ([#85](https://github.com/vaersaagod/seomate/issues/85))
+
+### Added
+- Added the ability to create field profiles specific to a particular section, entry type, category group or Commerce product type ([#86](https://github.com/vaersaagod/seomate/pull/86))  
+
 ## 3.0.0-beta.4 - 2024-04-04
 
 ### Fixed


### PR DESCRIPTION
This PR adds the ability to create more specific field profile mappings.

Previously, field profiles were mapped by simple handles only, where the key(s) would be matched to the elements' section or category group handles:  

```php
'profileMap' => [
    'news' => 'newsProfile',
],
```

The above config would result in the `newsProfile` field profile being used for elements belonging to either a section with the handle `news` or a category group with that same handle.

This PR retains this behaviour (and expands it to also include Craft Commerce products), but adds the ability to create more specific profile mappings by prefixing keys with either `section:`, `entryType:`, `categoryGroup:`, `productType:` or `user:`. As an example:

```php
'profileMap' => [
    'news' => 'newsProfile', // Matches entries, categories and products where either the section, entry type, category group or product type has the handle "news"
    'entryType:news' => 'newsBlockProfile', // Matches entries with an entry type "news" only
    'categoryGroup:news' => 'newsCategoryProfile', // Matches categories in a category group "news" only
    'productType:tShirts' => 'tShirtsProfile', // Matches products with a product type "tShirts" only
    'user:people' => 'userProfile', // Matches users only
],
```

Profile mappings are matched from highest to lowest specificity, i.e. for entries SEOMate will first look for a matching profile using the "entryType:" or "section:" syntax, before looking at the "unspecific" profiles (i.e. the ones not using the "sourceType:handle" syntax. Similarly for categories, SEOMate will first look for a matching profile using the "categoryGroup:" syntax, before looking at the unspecific profiles. 

This PR should be mostly backwards compatible, but might require some adjustments to existing SEOMate config files in rare cases.

This PR also fixes #85, by making the `SEOMateHelper::getElementProfile()` method more defensive when querying for entry sections.