### PR TITLE
Feature/strip preview params (Craft 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - SEOMate now strips preview and token params from canonical and alternate URLs
 - SEOMate now uses elements' canonical ID when querying for alternates
+- SEOMate no longer reads or writes to the meta or sitemap caches for preview and/or tokenized requests
 ### Added
 - Added `seomate.home` (the current site's URL, stripped of preview and token params)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # SEOMate Changelog
 
+## Unreleased - 2024-08-23
+### Changed
+- SEOMate now strips preview and token params from canonical and alternate URLs
+
 ## 2.2.1 - 2024-04-04  
 ### Fixed  
 - Fixed a bug where SEOMate could attempt to use string values as callables in `additionalMeta`  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased - 2024-08-23
 ### Changed
 - SEOMate now strips preview and token params from canonical and alternate URLs
+- SEOMate now uses elements' canonical ID when querying for alternates 
 
 ## 2.2.1 - 2024-04-04  
 ### Fixed  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## Unreleased - 2024-08-23
 ### Changed
 - SEOMate now strips preview and token params from canonical and alternate URLs
-- SEOMate now uses elements' canonical ID when querying for alternates 
+- SEOMate now uses elements' canonical ID when querying for alternates
+### Added
+- Added `seomate.home` (the current site's URL, stripped of preview and token params)
 
 ## 2.2.1 - 2024-04-04  
 ### Fixed  

--- a/src/SEOMate.php
+++ b/src/SEOMate.php
@@ -237,10 +237,12 @@ class SEOMate extends Plugin
         $meta = $this->meta->getContextMeta($context);
         $canonicalUrl = $this->urls->getCanonicalUrl($context);
         $alternateUrls = $this->urls->getAlternateUrls($context);
+        $home = $this->urls->getHomeUrl();
 
         $context['seomate']['meta'] = $meta;
         $context['seomate']['canonicalUrl'] = $canonicalUrl;
         $context['seomate']['alternateUrls'] = $alternateUrls;
+        $context['seomate']['home'] = $home;
 
         if ($settings['metaTemplate'] !== '') {
             return $craft->view->renderTemplate($settings['metaTemplate'], $context);

--- a/src/helpers/SEOMateHelper.php
+++ b/src/helpers/SEOMateHelper.php
@@ -353,12 +353,6 @@ class SEOMateHelper
         if (empty($url) || !is_string($url)) {
             return '';
         }
-        $parsedUrl = parse_url($url) ?: [];
-        $queryString = $parsedUrl['query'] ?? null;
-        if (empty($queryString)) {
-            return $url;
-        }
-        parse_str($queryString, $queryParams);
         $queryParamsToRemove = [
             Craft::$app->getConfig()->getGeneral()->tokenParam,
             Craft::$app->getConfig()->getGeneral()->siteToken,
@@ -366,12 +360,7 @@ class SEOMateHelper
             'x-craft-preview',
         ];
         foreach ($queryParamsToRemove as $queryParamToRemove) {
-            unset($queryParams[$queryParamToRemove]);
-        }
-        $newQueryString = http_build_query($queryParams);
-        $url = trim(str_replace($queryString, $newQueryString, $url));
-        if (empty($newQueryString)) {
-            $url = rtrim($url, '?');
+            $url = UrlHelper::removeParam($url, $queryParamToRemove);
         }
         return $url;
     }

--- a/src/helpers/SEOMateHelper.php
+++ b/src/helpers/SEOMateHelper.php
@@ -343,4 +343,36 @@ class SEOMateHelper
         // huh, relative url? Seems unlikely, but... If we've come this far.
         return $scheme . '://' . $siteUrlParts['host'] . '/' . $url;
     }
+
+    /**
+     * @param mixed $url
+     * @return string
+     */
+    public static function stripTokenParams(mixed $url): string
+    {
+        if (empty($url) || !is_string($url)) {
+            return '';
+        }
+        $parsedUrl = parse_url($url) ?: [];
+        $queryString = $parsedUrl['query'] ?? null;
+        if (empty($queryString)) {
+            return $url;
+        }
+        parse_str($queryString, $queryParams);
+        $queryParamsToRemove = [
+            Craft::$app->getConfig()->getGeneral()->tokenParam,
+            Craft::$app->getConfig()->getGeneral()->siteToken,
+            'x-craft-live-preview',
+            'x-craft-preview',
+        ];
+        foreach ($queryParamsToRemove as $queryParamToRemove) {
+            unset($queryParams[$queryParamToRemove]);
+        }
+        $newQueryString = http_build_query($queryParams);
+        $url = trim(str_replace($queryString, $newQueryString, $url));
+        if (empty($newQueryString)) {
+            $url = rtrim($url, '?');
+        }
+        return $url;
+    }
 }

--- a/src/helpers/SitemapHelper.php
+++ b/src/helpers/SitemapHelper.php
@@ -219,7 +219,7 @@ class SitemapHelper
                 unset($url['alternate']);
 
                 foreach ($url as $key => $val) {
-                    $node = $document->createElement($key, $val);
+                    $node = $document->createElement($key, SEOMateHelper::stripTokenParams($val));
                     $topNode->appendChild($node);
                 }
 
@@ -227,7 +227,7 @@ class SitemapHelper
                     $node = $document->createElement('xhtml:link');
                     $node->setAttribute('rel', 'alternate');
                     $node->setAttribute('hreflang', $alternate['hreflang']);
-                    $node->setAttribute('href', $alternate['href']);
+                    $node->setAttribute('href', SEOMateHelper::stripTokenParams($alternate['href']));
                     $topNode->appendChild($node);
                 }
 

--- a/src/services/MetaService.php
+++ b/src/services/MetaService.php
@@ -50,7 +50,7 @@ class MetaService extends Component
         }
 
         // Check if we have a cache
-        if ($element && $settings->cacheEnabled && CacheHelper::hasMetaCacheForElement($element)) {
+        if ($element && CacheHelper::hasMetaCacheForElement($element)) {
             return CacheHelper::getMetaCacheForElement($element);
         }
 
@@ -98,7 +98,7 @@ class MetaService extends Component
         }
         
         // Cache it
-        if ($element && $settings->cacheEnabled) {
+        if ($element) {
             CacheHelper::setMetaCacheForElement($element, $meta);
         }
 

--- a/src/services/SitemapService.php
+++ b/src/services/SitemapService.php
@@ -36,7 +36,7 @@ class SitemapService extends Component
         $settings = SEOMate::$plugin->getSettings();
         $siteId = Craft::$app->getSites()->getCurrentSite()->id;
 
-        if ($settings->cacheEnabled && CacheHelper::hasCacheForSitemapIndex($siteId)) {
+        if (CacheHelper::hasCacheForSitemapIndex($siteId)) {
             return CacheHelper::getCacheForSitemapIndex($siteId);
         }
 
@@ -138,7 +138,7 @@ class SitemapService extends Component
                 return $document->saveXML();
             }
 
-            if ($settings->cacheEnabled && CacheHelper::hasCacheForElementSitemap($siteId, $handle, $page)) {
+            if (CacheHelper::hasCacheForElementSitemap($siteId, $handle, $page)) {
                 return CacheHelper::getCacheForElementSitemap($siteId, $handle, $page);
             }
 

--- a/src/services/UrlsService.php
+++ b/src/services/UrlsService.php
@@ -149,4 +149,13 @@ class UrlsService extends Component
         return $alternateUrls;
     }
 
+    /**
+     * @return string
+     * @throws Exception
+     */
+    public function getHomeUrl(): string
+    {
+        return SEOMateHelper::stripTokenParams(UrlHelper::siteUrl());
+    }
+
 }

--- a/src/services/UrlsService.php
+++ b/src/services/UrlsService.php
@@ -113,12 +113,12 @@ class UrlsService extends Component
             $element = $craft->urlManager->getMatchedElement();
         }
 
-        if (!$element instanceof ElementInterface) {
+        if (!$element instanceof ElementInterface || empty($element->canonicalId)) {
             return [];
         }
 
         $siteElements = $element::find()
-            ->id($element->id)
+            ->id($element->canonicalId)
             ->siteId('*')
             ->collect()
             ->filter(static fn(ElementInterface $element) => !empty($element->getUrl()));

--- a/src/services/UrlsService.php
+++ b/src/services/UrlsService.php
@@ -49,7 +49,7 @@ class UrlsService extends Component
         }
 
         if (isset($overrideObject['canonicalUrl']) && $overrideObject['canonicalUrl'] !== '') {
-            return $overrideObject['canonicalUrl'];
+            return SEOMateHelper::stripTokenParams($overrideObject['canonicalUrl']);
         }
 
         /** @var Element $element */
@@ -71,18 +71,18 @@ class UrlsService extends Component
 
         $page = Craft::$app->getRequest()->getPageNum();
         if ($page <= 1) {
-            return UrlHelper::siteUrl($path, null, null, $siteId);
+            return SEOMateHelper::stripTokenParams(UrlHelper::siteUrl($path, null, null, $siteId));
         }
 
         $pageTrigger = Craft::$app->getConfig()->getGeneral()->getPageTrigger();
         $useQueryParam = str_starts_with($pageTrigger, '?');
         if ($useQueryParam) {
             $param = trim($pageTrigger, '?=');
-            return UrlHelper::siteUrl($path, [$param => $page], null, $siteId);
+            return SEOMateHelper::stripTokenParams(UrlHelper::siteUrl($path, [$param => $page], null, $siteId));
         }
 
         $path .= '/' . $pageTrigger . $page;
-        return UrlHelper::siteUrl($path, null, null, $siteId);
+        return SEOMateHelper::stripTokenParams(UrlHelper::siteUrl($path, null, null, $siteId));
     }
 
     /**
@@ -131,7 +131,7 @@ class UrlsService extends Component
             $fallbackSiteElement = $siteElements->firstWhere('siteId', $fallbackSite->id);
             if ($fallbackSiteElement) {
                 $alternateUrls[] = [
-                    'url' => $fallbackSiteElement->getUrl(),
+                    'url' => SEOMateHelper::stripTokenParams($fallbackSiteElement->getUrl()),
                     'language' => 'x-default',
                 ];
                 $siteElements = $siteElements->where('siteId', '!=', $fallbackSite->id);
@@ -141,7 +141,7 @@ class UrlsService extends Component
         /** @var ElementInterface $siteElement */
         foreach ($siteElements->all() as $siteElement) {
             $alternateUrls[] = [
-                'url' => $siteElement->getUrl(),
+                'url' => SEOMateHelper::stripTokenParams($siteElement->getUrl()),
                 'language' => strtolower(str_replace('_', '-', $siteElement->getLanguage())),
             ];
         }

--- a/src/templates/_output/meta.twig
+++ b/src/templates/_output/meta.twig
@@ -1,5 +1,5 @@
 {% set meta = seomate.meta %}
-<link rel="home" href="{{ siteUrl() }}">
+<link rel="home" href="{{ seomate.home }}">
 {% if craft.app.getResponse().getStatusCode() < 400 %}
 <link rel="canonical" href="{{ seomate.canonicalUrl }}">
 {% if meta['og:url'] is not defined %}<meta property="og:url" content="{{ seomate.canonicalUrl }}">{% endif %}

--- a/src/variables/SEOMateVariable.php
+++ b/src/variables/SEOMateVariable.php
@@ -9,6 +9,7 @@
 namespace vaersaagod\seomate\variables;
 
 use craft\helpers\Template;
+use craft\helpers\UrlHelper;
 use Twig\Markup;
 use vaersaagod\seomate\helpers\SEOMateHelper;
 use vaersaagod\seomate\SEOMate;
@@ -49,11 +50,13 @@ class SEOMateVariable
         $meta = SEOMate::$plugin->meta->getContextMeta($context);
         $canonicalUrl = SEOMate::$plugin->urls->getCanonicalUrl($context);
         $alternateUrls = SEOMate::$plugin->urls->getAlternateUrls($context);
+        $home = SEOMate::$plugin->urls->getHomeUrl();
 
         return [
             'meta' => $meta,
             'canonicalUrl' => $canonicalUrl,
             'alternateUrls' => $alternateUrls,
+            'home' => $home,
         ];
     }
 }

--- a/src/variables/SEOMateVariable.php
+++ b/src/variables/SEOMateVariable.php
@@ -10,6 +10,7 @@ namespace vaersaagod\seomate\variables;
 
 use craft\helpers\Template;
 use Twig\Markup;
+use vaersaagod\seomate\helpers\SEOMateHelper;
 use vaersaagod\seomate\SEOMate;
 
 /**
@@ -30,6 +31,10 @@ class SEOMateVariable
 
     public function breadcrumbSchema(array $breadcrumbArray): Markup
     {
+        $breadcrumbArray = array_map(static function (array $crumb) {
+            $crumb['url'] = SEOMateHelper::stripTokenParams($crumb['url']);
+            return $crumb;
+        }, $breadcrumbArray);
         $breadcrumbList = SEOMate::$plugin->schema->breadcrumb($breadcrumbArray);
         return Template::raw($breadcrumbList->toScript());
     }


### PR DESCRIPTION
Strips preview and token params from canonical and alternate URLs.
Also disables meta and sitemap caching for preview and/or tokenized requests.