### PR TITLE
Fix TOCTOU cache race in getContextMeta()

### DIFF
--- a/src/helpers/CacheHelper.php
+++ b/src/helpers/CacheHelper.php
@@ -116,18 +116,19 @@ class CacheHelper
     }
 
     /**
-     * Returns meta data cache for element
+     * Returns meta data cache for element, or null on cache miss
      *
      * @param $element
-     * @return mixed
+     * @return array|null
      * @throws \yii\web\BadRequestHttpException
      */
-    public static function getMetaCacheForElement($element): mixed
+    public static function getMetaCacheForElement($element): ?array
     {
         if (!self::getIsCacheEnabled()) {
-            return false;
+            return null;
         }
-        return Craft::$app->getCache()?->get(self::getElementKey($element));
+        $cached = Craft::$app->getCache()?->get(self::getElementKey($element));
+        return is_array($cached) ? $cached : null;
     }
 
     /**

--- a/src/services/MetaService.php
+++ b/src/services/MetaService.php
@@ -49,9 +49,12 @@ class MetaService extends Component
             $element = $craft->urlManager->getMatchedElement();
         }
 
-        // Check if we have a cache
-        if ($element && CacheHelper::hasMetaCacheForElement($element)) {
-            return CacheHelper::getMetaCacheForElement($element);
+        // Check if we have a cache (single call to avoid TOCTOU race condition)
+        if ($element) {
+            $cached = CacheHelper::getMetaCacheForElement($element);
+            if (is_array($cached)) {
+                return $cached;
+            }
         }
 
         $meta = [];


### PR DESCRIPTION
## Summary

`MetaService::getContextMeta()` calls `hasMetaCacheForElement()` and `getMetaCacheForElement()` as two separate cache lookups. If the cache entry expires between the two calls, `getMetaCacheForElement()` returns `false`, violating the method's `: array` return type and causing a `TypeError` that crashes the page with a 500 error.

```
TypeError: vaersaagod\seomate\services\MetaService::getContextMeta():
Return value must be of type array, false returned
  at vendor/vaersaagod/seomate/src/services/MetaService.php:54
```

## Changes

- Collapse the two separate cache calls into a single `getMetaCacheForElement()` call with a type check on the result
- Tighten `CacheHelper::getMetaCacheForElement()` return type from `mixed` to `?array`, returning `null` instead of `false` on cache miss

The race window is small but we've observed it causing intermittent 500 errors on production under normal traffic, with Redis as the cache backend.